### PR TITLE
First area Narrative

### DIFF
--- a/Assets/Art/NPCs/NPC 2/Jessamine NPC Interactable.png.meta
+++ b/Assets/Art/NPCs/NPC 2/Jessamine NPC Interactable.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Jessamine NPC Interactable_0: -2143945735860372731
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Art/NPCs/NPC 2/Jessamine NPC Neutral.png.meta
+++ b/Assets/Art/NPCs/NPC 2/Jessamine NPC Neutral.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Jessamine NPC Neutral_0: -4840500158256232574
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Art/NPCs/NPC 3/LADY ELOISE NPC Interactable.png.meta
+++ b/Assets/Art/NPCs/NPC 3/LADY ELOISE NPC Interactable.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      LADY ELOISE NPC Interactable_0: 7236183288471071128
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Scripts/Narrative/Alcove.yarnproject
+++ b/Assets/Scripts/Narrative/Alcove.yarnproject
@@ -1,0 +1,14 @@
+﻿{
+  "projectFileVersion": 3,
+  "sourceFiles": [
+    "**/*.yarn"
+  ],
+  "excludeFiles": [
+    "**/*~/*",
+    "./Samples/Yarn Spinner*/*"
+  ],
+  "localisation": {},
+  "baseLanguage": "en",
+  "compilerOptions": {},
+  "definitionsFiles": []
+}

--- a/Assets/Scripts/Narrative/Alcove.yarnproject.meta
+++ b/Assets/Scripts/Narrative/Alcove.yarnproject.meta
@@ -1,0 +1,17 @@
+fileFormatVersion: 2
+guid: 6f04c9b59b73042afb0c0609494dd144
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 053561912b1654d80a424bb0696a74ae, type: 3}
+  generateVariablesSourceFile: 0
+  variablesClassName: YarnVariables
+  variablesClassNamespace: 
+  variablesClassParent: Yarn.Unity.InMemoryVariableStorage
+  useAddressableAssets: 0
+  unityLocalisationStringTableCollectionGUID: 
+  UseUnityLocalisationSystem: 0

--- a/Assets/Scripts/Narrative/AlcoveScript.yarn
+++ b/Assets/Scripts/Narrative/AlcoveScript.yarn
@@ -1,0 +1,32 @@
+﻿title: AlcoveScript
+---
+<<declare $mainCharName = "Nisaea">>
+<<declare $expression = "Neutral">>
+Narrator: Crashing waves echo off the cave walls, a sound like a constant ringing which never fully deserts the space. The sun bathes the walls in honeyed rays that gently heat them like palming a mug of warmed tea. 
+Narrator: Dampened sand coats each splayed digit of Nisaea's fresh, human, toes as she carefully scales the outside wall of the alcove. Dipping inside quickly to ensure no one sees her Nesaea lets out a loud groan.
+Nisaea: "My precious time wasted on command. I ought to be with my pod, hunting, rendering myself useful. I would rather watch pups or feed elders than suffer what turned out to be a trivial errand. I'll return with few fish more than we had, so I suppose what reason have I to cavil?"
+Narrator: Nisaea looped the string of fish she bartered for around her waist and began looking in the sand for her pelt.
+-> Footprints
+	<<jump footprint_clue>>
+===
+title: footprint_clue
+---
+<<expression Nisaea Nervous>>
+Narrator: A footprint larger than her own is preserved in the damp sand near the edge of the alcove mouth. It looks as if someone tried to disturb it get rid of the print alltogether, but was in too much of a hurry to successfully destroy it. Upon closer inspection, the print is a shoeprint, one, Nisaea can fit her entire human foot inside of. 
+Nisaea: Who would wear their boots upon the strand?
+-> Overturned Rock
+	<<jump overturnedrock_clue>>
+===
+title: overturnedrock_clue
+---
+<<expression Nisaea Angry>>
+Narrator:A large, smooth rock is sprayed wet with sea water. It is ashy and flaking with salt in the areas it's since dried off, and in the depressions brilliant pink coraline algae has made it's home making it difficult to grip it from any angle. Yet, the rock seems to have been disturbed, with sand bunched up around the edges of it where it has been dragged from it's original position. 
+Narrator: Nisaea's pelt is missing from it's hiding spot.
+<<expression Nisaea Sad>>
+Narrator: Nisaea's heart began to race. She can't differentiate between the sound of blood rushing in hear ears and the waves creeping in to deposit sea foam on her feet. A guttural wail leaves her body, startling the gulls from their cozy perches. Nesaea is stranded. Without her pelt she can't return to her pod. She can never return home again. 
+Nisaea:"I exercised caution. I obscured my passage. Who might have tracked me?– Who desires to harm me?"
+Narrator: Nisaea palmed the footprints and eyed the direction it was headed in. 
+Nisaea:"It's wends its way toward the town. Maybe I can find clues there."
+
+<<change_scene Townsquare>>
+===

--- a/Assets/Scripts/Narrative/AlcoveScript.yarn.meta
+++ b/Assets/Scripts/Narrative/AlcoveScript.yarn.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4d26e8e28aed04e2aaef306a5fd38778
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}


### PR DESCRIPTION
I redid the narrative removing the DETOUR Command and replacing it with the JUMP command. It will need to be replaced with the point and click mechanic since it's not actual branching dialogue, but I figured NQ and I would go over that post alpha presentation. It should be identical to the sample script. I got 4 minor errors in that it was unable to find certain Nisaea expressions and the townsquare location when trying to find it in unity, but I figure that was because it hadn't been officially added by Art yet and would be tomorrow. Tested in Yarnspinner web and it worked (I still cant access anything in unity on my mac however).