### PR TITLE
Minor changes to help synchronize the aesthetic of areas.

### DIFF
--- a/Assets/Scenes/Beach.unity
+++ b/Assets/Scenes/Beach.unity
@@ -696,18 +696,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 2121212282}
-        m_TargetAssemblyTypeName: Yarn.Unity.DialogueRunner, YarnSpinner.Unity
-        m_MethodName: StartDialogue
-        m_Mode: 5
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: overturnedrock_clue
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!114 &189246858
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1152,18 +1140,6 @@ MonoBehaviour:
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2121212282}
-        m_TargetAssemblyTypeName: Yarn.Unity.DialogueRunner, YarnSpinner.Unity
-        m_MethodName: StartDialogue
-        m_Mode: 5
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: footprint_clue
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &443776625
@@ -2272,6 +2248,18 @@ MonoBehaviour:
           m_IntArgument: 12
           m_FloatArgument: 0
           m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 2121212282}
+        m_TargetAssemblyTypeName: Yarn.Unity.DialogueRunner, YarnSpinner.Unity
+        m_MethodName: StartDialogue
+        m_Mode: 5
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: overturnedrock_clue
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!1 &895049382
@@ -3962,6 +3950,18 @@ MonoBehaviour:
           m_IntArgument: 12
           m_FloatArgument: 0
           m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 2121212282}
+        m_TargetAssemblyTypeName: Yarn.Unity.DialogueRunner, YarnSpinner.Unity
+        m_MethodName: StartDialogue
+        m_Mode: 5
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: footprint_clue
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &2121212282 stripped

--- a/Assets/Scripts/Narrative/AlcoveScript.yarn
+++ b/Assets/Scripts/Narrative/AlcoveScript.yarn
@@ -12,16 +12,22 @@ Narrator:Nisaea looped the string of fish she bartered for around her waist and 
 title: footprint_clue
 ---
 <<expression Nisaea Nervous>>
-Narrator: A footprint larger than her own is preserved in the damp sand near the edge of the alcove mouth. It looks as if someone tried to disturb it get rid of the print alltogether, but was in too much of a hurry to successfully destroy it. Upon closer inspection, the print is a shoeprint, one, Nisaea can fit her entire human foot inside of. 
+Narrator:A footprint larger than her own is preserved in the damp sand near the edge of the alcove mouth.
+Narrator:It looks as if someone tried to disturb it get rid of the print alltogether, but was in too much of a hurry to successfully destroy it.
+Narrator:Upon closer inspection, the print is a shoeprint, one, Nisaea can fit her entire human foot inside of. 
 Nisaea: Who would wear their boots upon the strand?
 ===
 title: overturnedrock_clue
 ---
 <<expression Nisaea Angry>>
-Narrator:A large, smooth rock is sprayed wet with sea water. It is ashy and flaking with salt in the areas it's since dried off, and in the depressions brilliant pink coraline algae has made it's home making it difficult to grip it from any angle. Yet, the rock seems to have been disturbed, with sand bunched up around the edges of it where it has been dragged from it's original position. 
-Narrator: Nisaea's pelt is missing from it's hiding spot.
+Narrator:A large, smooth rock is sprayed wet with sea water. 
+Narrator:It is ashy and flaking with salt in the areas it's since dried off, and in the depressions brilliant pink coraline algae has made it's home making it difficult to grip it from any angle. 
+Narrator:Yet, the rock seems to have been disturbed, with sand bunched up around the edges of it where it has been dragged from it's original position. 
+Narrator:Nisaea's pelt is missing from it's hiding spot.
 <<expression Nisaea Nervous>>
-Narrator: Nisaea's heart began to race. She can't differentiate between the sound of blood rushing in hear ears and the waves creeping in to deposit sea foam on her feet. A guttural wail leaves her body, startling the gulls from their cozy perches. Nisaea is stranded. Without her pelt she can't return to her pod. She can never return home again. 
+Narrator:Nisaea's heart began to race. She can't differentiate between the sound of blood rushing in hear ears and the waves creeping in to deposit sea foam on her feet.
+Narrator:A guttural wail leaves her body, startling the gulls from their cozy perches. 
+Narrator:Nisaea is stranded. Without her pelt she can't return to her pod. She can never return home again. 
 Nisaea:"I exercised caution. I obscured my passage. Who might have tracked me?– Who desires to harm me?"
 Narrator: Nisaea palmed the footprints and eyed the direction it was headed in. 
 Nisaea:"It's wends its way toward the town. Maybe I can find clues there."

--- a/Assets/Scripts/Narrative/TownsquareScript.yarn
+++ b/Assets/Scripts/Narrative/TownsquareScript.yarn
@@ -16,11 +16,11 @@ Victor:"Darling. Sorry, I have no crab for you today– traps were empty. I thou
 Nisaea:"Oh.."
     ->"I missed Point Ecrin already!"
         <<set $reputation to $reputation -1>>
-         Narrator: Your ending repuation is {$reputation}! // for debugging
+         Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump VD1NEG>>
     ->"I've lost something..."
         <<set $reputation to $reputation +1>>
-         Narrator: Your ending repuation is {$reputation}! // for debugging
+         Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump VD1POS>>
 ===
 

--- a/Assets/Scripts/Narrative/TownsquareScript.yarn
+++ b/Assets/Scripts/Narrative/TownsquareScript.yarn
@@ -16,11 +16,11 @@ Victor:"Darling. Sorry, I have no crab for you today– traps were empty. I thou
 Nisaea:"Oh.."
     ->"I missed Point Ecrin already!"
         <<set $reputation to $reputation -1>>
-         Narrator: Your current repuation is {$reputation}! // for debugging
+        //  Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump VD1NEG>>
     ->"I've lost something..."
         <<set $reputation to $reputation +1>>
-         Narrator: Your current repuation is {$reputation}! // for debugging
+        //  Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump VD1POS>>
 ===
 
@@ -125,7 +125,7 @@ Narrator: Nisaea interrupts Victor, showing him the precious ring.
 Victor:"By the gods! You found it! I've been looking all over for this."
     -><color=red>"What do the scratches inside mean?"</color>
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         Victor:"Family over everything. We protect each other first and foremost." 
             -><color=red>"You have kin?"</color>
                 Victor:"I.. have a younger sister. My father and mother passed away a few years ago one after the other. Broken heart I suspect."
@@ -150,7 +150,7 @@ Narrator: Nisaea interrupts Victor, showing him the delicate scissors.
 Victor:"How did those fall out of my pocket?"
 Nisaea:"Carrying bloody scissors a vice of yours?"
 <<set $reputation to $reputation +1>>
-Narrator: Your current repuation is {$reputation}! // for debugging
+// Narrator: Your current repuation is {$reputation}! // for debugging
 Victor:"I'm sure it looks odd, but spare me a sentencing."
 Victor:"My sister gifted these to me."
 Victor:"She's an amazing needleworker and swore these types of scissors were sharp and precise."
@@ -176,11 +176,11 @@ title: EloiseOpening
  Nisaea: Pardon. Are you...
     ->"The Keatings' Daughter?"
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EVDPOS1>>
     ->"Ms.Eliza or Elsa?"
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EVDNeg1>>
 ===
 
@@ -211,7 +211,7 @@ Eloise:"What great honors' bestowed upon me, that fate caused us to meet?"
 Nisaea:"I'm searching for someone. Someone I believe to be a thief."
 Eloise:"And you think I'd fraternize with that sort?"
 <<set $reputation to $reputation -1>>
-Narrator: Your current repuation is {$reputation}! // for debugging
+// Narrator: Your current repuation is {$reputation}! // for debugging
 <<expression Nisaea angry>>
 Nisaea:"No! 
 <<jump NEIQ>>
@@ -284,11 +284,11 @@ Nisaea:"I found it! I think it fell out of your purse."
 Narrator:Eloise promptly snatches the handkerchief and looks over the embroidery to check for new imperfections. 
     -> "It must mean a lot. What it's story?"
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ECNeg>>
     ->"Its beautiful. Did you make it?"
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ECPos>>
 ===
 
@@ -309,11 +309,11 @@ Nisaea:"That's Victor's sister, yes?"
 Eloise:"The crab fisherman? Yes. It often slips my mind that they're related, they feel so diametric to one another." 
     -> "You commissioned this handkerchief from her?"
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EComL>>
     -> "You speak tenderly of her. Are you friends?"
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ETL>>
 ===
 
@@ -397,7 +397,7 @@ Unknown: "Awfully sorry, We're closed."
         <<jump JVDNeut1>>
     ->Victor sent me. He said you could be a friend.
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JVDPOS1>>
 ===
 
@@ -485,20 +485,20 @@ Narrator:Jessamine knots a final thread in her fabric and cuts it precisely with
 Jessamine:"Alright, that's enough for tonight don't you think?"
     ->"I've never seen a book like this. Is it from far away?"
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging 
+        // Narrator: Your current repuation is {$reputation}! // for debugging 
     ->"Your bookmark is beautiful."
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
 Nisaea:"I've never seen a book with names like these. Is it from a land far away?"
 <<expression Jessa sad>>
 Jessamine:"It is. It's imported. A...friend.... got it for me."
     ->"Why are your spirits low?"
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JMDPostCont>>
     ->"That's a generous gift from a friend."
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JGL>>
 ===
 
@@ -521,10 +521,10 @@ Jessamine:"May I ask you an absurd question?"
 Jessamine:"Do you think the ocean would be greedy to yearn for the moon?"
     ->"Yes."
         <<set $reputation to $reputation -1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
     ->"No."
         <<set $reputation to $reputation +1>>
-        Narrator: Your current repuation is {$reputation}! // for debugging
+        // Narrator: Your current repuation is {$reputation}! // for debugging
 Jessamine:"Then no. It's more akin to missing several meals and your ribs start to ache, but I'm still eating. I'm unsure if I'll ever be full again."
 Jessamine:"My apologies... 
     <<jump JEnd>>

--- a/Assets/Scripts/Narrative/TownsquareScript.yarn
+++ b/Assets/Scripts/Narrative/TownsquareScript.yarn
@@ -53,7 +53,7 @@ Nisaea: Victor...
 title: VD1NEUT
 ---
 Victor:"You'll have to be more specific. 'Er's never a dull moment in Ecrin." 
-Victor:"Jilted brides, natural philosophers from out of town, mysterious women blowing in from the southern seas, much like yourself– All the residents are characters. "
+Victor:"Jilted brides, natural philosophers from out of town, mysterious women blowing in from the southern seas, much like yourself- All the residents are characters. "
 <<if visited ("VD2NEUT")>>
     <<jump NRVMDB1>>
        <<else>>
@@ -125,6 +125,7 @@ Narrator: Nisaea interrupts Victor, showing him the precious ring.
 Victor:"By the gods! You found it! I've been looking all over for this."
     -><color=red>"What do the scratches inside mean?"</color>
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         Victor:"Family over everything. We protect each other first and foremost." 
             -><color=red>"You have kin?"</color>
                 Victor:"I.. have a younger sister. My father and mother passed away a few years ago one after the other. Broken heart I suspect."
@@ -149,6 +150,7 @@ Narrator: Nisaea interrupts Victor, showing him the delicate scissors.
 Victor:"How did those fall out of my pocket?"
 Nisaea:"Carrying bloody scissors a vice of yours?"
 <<set $reputation to $reputation +1>>
+Narrator: Your current repuation is {$reputation}! // for debugging
 Victor:"I'm sure it looks odd, but spare me a sentencing."
 Victor:"My sister gifted these to me."
 Victor:"She's an amazing needleworker and swore these types of scissors were sharp and precise."
@@ -174,9 +176,11 @@ title: EloiseOpening
  Nisaea: Pardon. Are you...
     ->"The Keatings' Daughter?"
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EVDPOS1>>
     ->"Ms.Eliza or Elsa?"
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EVDNeg1>>
 ===
 
@@ -207,6 +211,7 @@ Eloise:"What great honors' bestowed upon me, that fate caused us to meet?"
 Nisaea:"I'm searching for someone. Someone I believe to be a thief."
 Eloise:"And you think I'd fraternize with that sort?"
 <<set $reputation to $reputation -1>>
+Narrator: Your current repuation is {$reputation}! // for debugging
 <<expression Nisaea angry>>
 Nisaea:"No! 
 <<jump NEIQ>>
@@ -255,7 +260,7 @@ title: handkerchief
 Narrator:A silken white handkerchief with skillfully embroidered violet and lavender flowers. 
 Narrator:Either imported or commissioned for an appropriate price. 
 Narrator:The letters E.K are painstalingly sewn into the corner of the fabric.
-Nisaea: "What beautiful flowers... I wonder if this belongs to Ms. Keating."
+Nisaea:"What beautiful flowers... I wonder if this belongs to Ms. Keating."
 //transition back to option to interact with Eloise.
     <<jump EHKC>>
 ===
@@ -269,7 +274,7 @@ Eloise: "I already told you, I can't help you."
 
 //presenting the handkerchief
 
-Nisaea:"Is this–"
+Nisaea:"Is this-"
 <<expression Eloise guarded>>
 Eloise: Thief!
 <<expression Nisaea nervous>>
@@ -279,9 +284,11 @@ Nisaea:"I found it! I think it fell out of your purse."
 Narrator:Eloise promptly snatches the handkerchief and looks over the embroidery to check for new imperfections. 
     -> "It must mean a lot. What it's story?"
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ECNeg>>
     ->"Its beautiful. Did you make it?"
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ECPos>>
 ===
 
@@ -302,16 +309,18 @@ Nisaea:"That's Victor's sister, yes?"
 Eloise:"The crab fisherman? Yes. It often slips my mind that they're related, they feel so diametric to one another." 
     -> "You commissioned this handkerchief from her?"
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump EComL>>
     -> "You speak tenderly of her. Are you friends?"
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump ETL>>
 ===
 
 title: EComL
 ---
 <<expression Eloise condescending>>
-Eloise:"I wouldn't waste her time with such a pitiful project. I'd ask for a veil or gloves– something grand."
+Eloise:"I wouldn't waste her time with such a pitiful project. I'd ask for a veil or gloves- something grand."
 Eloise:"It was a gift, of course." 
 Nisaea:"So you're quite close?"
 Narrator: Eloise fidgets with the handkerchief.
@@ -388,6 +397,7 @@ Unknown: "Awfully sorry, We're closed."
         <<jump JVDNeut1>>
     ->Victor sent me. He said you could be a friend.
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JVDPOS1>>
 ===
 
@@ -474,17 +484,21 @@ title: JMDPost
 Narrator:Jessamine knots a final thread in her fabric and cuts it precisely with her scissors before folding it away neatly. 
 Jessamine:"Alright, that's enough for tonight don't you think?"
     ->"I've never seen a book like this. Is it from far away?"
-        <<set $reputation to $reputation +1>> 
+        <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging 
     ->"Your bookmark is beautiful."
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
 Nisaea:"I've never seen a book with names like these. Is it from a land far away?"
 <<expression Jessa sad>>
 Jessamine:"It is. It's imported. A...friend.... got it for me."
     ->"Why are your spirits low?"
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JMDPostCont>>
     ->"That's a generous gift from a friend."
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
         <<jump JGL>>
 ===
 
@@ -507,8 +521,10 @@ Jessamine:"May I ask you an absurd question?"
 Jessamine:"Do you think the ocean would be greedy to yearn for the moon?"
     ->"Yes."
         <<set $reputation to $reputation -1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
     ->"No."
         <<set $reputation to $reputation +1>>
+        Narrator: Your current repuation is {$reputation}! // for debugging
 Jessamine:"Then no. It's more akin to missing several meals and your ribs start to ache, but I'm still eating. I'm unsure if I'll ever be full again."
 Jessamine:"My apologies... 
     <<jump JEnd>>

--- a/Assets/Scripts/Narrative/TownsquareScript.yarn
+++ b/Assets/Scripts/Narrative/TownsquareScript.yarn
@@ -16,9 +16,11 @@ Victor:"Darling. Sorry, I have no crab for you today– traps were empty. I thou
 Nisaea:"Oh.."
     ->"I missed Point Ecrin already!"
         <<set $reputation to $reputation -1>>
+         Narrator: Your ending repuation is {$reputation}! // for debugging
         <<jump VD1NEG>>
     ->"I've lost something..."
         <<set $reputation to $reputation +1>>
+         Narrator: Your ending repuation is {$reputation}! // for debugging
         <<jump VD1POS>>
 ===
 

--- a/Assets/Scripts/Narrative/Warehouse.yarn
+++ b/Assets/Scripts/Narrative/Warehouse.yarn
@@ -65,7 +65,7 @@ Dr. Ellis:"Ondine."
 Dr. Ellis:"My pearl. I had never thought to gaze upon those eyes again."
 // <<set $reputation += 1>>
 <<set $reputation -= 1>>
-// Narrator: Your ending repuation is {$reputation}! // for debugging
+ Narrator: Your ending repuation is {$reputation}! // for debugging
 <<if $reputation >= 10>>
   <<jump DEGoodEnding>>
 <<else>>

--- a/Assets/Scripts/Narrative/Warehouse.yarn
+++ b/Assets/Scripts/Narrative/Warehouse.yarn
@@ -65,7 +65,7 @@ Dr. Ellis:"Ondine."
 Dr. Ellis:"My pearl. I had never thought to gaze upon those eyes again."
 // <<set $reputation += 1>>
 <<set $reputation -= 1>>
- Narrator: Your ending repuation is {$reputation}! // for debugging
+//  Narrator: Your ending repuation is {$reputation}! // for debugging
 <<if $reputation >= 10>>
   <<jump DEGoodEnding>>
 <<else>>


### PR DESCRIPTION
Chunked up dialogue in Alcove area to re-enable the ability to use onclick (so boxes don't overlap) and the clues plus accompanying dialogue can show up at the same time and allow players to associate the clues with the associated dialogue and avoid confusion.